### PR TITLE
Set User-Agent when calling Exchange()

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ import(
 func main() {
   // Create a new authenticator with your app's client ID, secret, and redirect URI
   // A random string representing state and a list of requested OAuth scopes are required
-  authenticator := reddit.NewAuthenticator("<client_id>", "<client_secret>", "<redirect_uri>", "<random_string>", reddit.ScopeIdentity)
+  authenticator := reddit.NewAuthenticator("<client_id>", "<client_secret>", "<redirect_uri>", 
+     "<platform>:<app ID>:<version string> (by /u/<reddit username>)", "<random_string>", reddit.ScopeIdentity)
   
   // Instruct your user to visit the URL retrieved from GetAuthenticationURL in their web browser
   url := authenticator.GetAuthenticationURL()
@@ -49,7 +50,7 @@ func main() {
   token, err := authenticator.GetToken(state, code)
   
   // Create a new client using the access token and a user agent string to identify your application
-  client := authenticator.GetAuthClient(token, "<platform>:<app ID>:<version string> (by /u/<reddit username>)")
+  client := authenticator.GetAuthClient(token)
 }
 ````
 

--- a/authenticator.go
+++ b/authenticator.go
@@ -1,14 +1,19 @@
 package reddit
 
 import (
+	"context"
+	"encoding/base64"
 	"errors"
+	"net/http"
+
 	"golang.org/x/oauth2"
 )
 
 // Authenticator provides functions for authenticating a user via OAuth2 and generating a client that can be used to access authorized API endpoints.
 type Authenticator struct {
-	config *oauth2.Config
-	state  string
+	config    *oauth2.Config
+	state     string
+	userAgent string
 }
 
 const (
@@ -54,7 +59,7 @@ const (
 )
 
 // NewAuthenticator generates a new authenticator with the supplied client, state, and requested scopes.
-func NewAuthenticator(clientID string, clientSecret string, redirectURL string, state string, scopes ...string) *Authenticator {
+func NewAuthenticator(clientID string, clientSecret string, redirectURL string, userAgent string, state string, scopes ...string) *Authenticator {
 	config := &oauth2.Config{
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
@@ -66,12 +71,33 @@ func NewAuthenticator(clientID string, clientSecret string, redirectURL string, 
 		RedirectURL: redirectURL,
 	}
 
-	return &Authenticator{config: config, state: state}
+	return &Authenticator{
+		config:    config,
+		state:     state,
+		userAgent: userAgent,
+	}
 }
 
 // GetAuthenticationURL retrieves the URL used to direct the authenticating user to Reddit for permissions approval.
 func (a *Authenticator) GetAuthenticationURL() string {
 	return a.config.AuthCodeURL(a.state)
+}
+
+type uaSetterTransport struct {
+	config    *oauth2.Config
+	userAgent string
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func (t *uaSetterTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Set("User-Agent", t.userAgent)
+	req.Header.Set("Authorization", basicAuth(t.config.ClientID, t.config.ClientSecret))
+
+	return http.DefaultTransport.RoundTrip(req)
 }
 
 // GetToken exchanges an authorization code for an access token.
@@ -80,13 +106,31 @@ func (a *Authenticator) GetToken(state string, code string) (*oauth2.Token, erro
 		return nil, errors.New("Invalid state")
 	}
 
-	return a.config.Exchange(oauth2.NoContext, code)
+	tok := &oauth2.Token{
+		AccessToken: code,
+	}
+
+	tr := &oauth2.Transport{
+		Source: a.config.TokenSource(oauth2.NoContext, tok),
+		Base: &uaSetterTransport{
+			config:    a.config,
+			userAgent: a.userAgent,
+		},
+	}
+
+	client := &http.Client{
+		Transport: tr,
+	}
+
+	ctx := context.WithValue(oauth2.NoContext, oauth2.HTTPClient, client)
+
+	return a.config.Exchange(ctx, code)
 }
 
 // GetAuthClient generates a new authenticated client using the supplied access token.
-func (a *Authenticator) GetAuthClient(token *oauth2.Token, userAgent string) *Client {
+func (a *Authenticator) GetAuthClient(token *oauth2.Token) *Client {
 	return &Client{
 		http:      a.config.Client(oauth2.NoContext, token),
-		userAgent: userAgent,
+		userAgent: a.userAgent,
 	}
 }

--- a/authenticator.go
+++ b/authenticator.go
@@ -11,9 +11,10 @@ import (
 
 // Authenticator provides functions for authenticating a user via OAuth2 and generating a client that can be used to access authorized API endpoints.
 type Authenticator struct {
-	config    *oauth2.Config
-	state     string
-	userAgent string
+	config                *oauth2.Config
+	state                 string
+	userAgent             string
+	RequestPermanentToken bool
 }
 
 const (
@@ -80,7 +81,11 @@ func NewAuthenticator(clientID string, clientSecret string, redirectURL string, 
 
 // GetAuthenticationURL retrieves the URL used to direct the authenticating user to Reddit for permissions approval.
 func (a *Authenticator) GetAuthenticationURL() string {
-	return a.config.AuthCodeURL(a.state)
+	url := a.config.AuthCodeURL(a.state)
+	if a.RequestPermanentToken {
+		url += "&duration=permanent"
+	}
+	return url
 }
 
 type uaSetterTransport struct {
@@ -96,7 +101,6 @@ func basicAuth(username, password string) string {
 func (t *uaSetterTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Set("User-Agent", t.userAgent)
 	req.Header.Set("Authorization", basicAuth(t.config.ClientID, t.config.ClientSecret))
-
 	return http.DefaultTransport.RoundTrip(req)
 }
 

--- a/authenticator_test.go
+++ b/authenticator_test.go
@@ -1,13 +1,18 @@
 package reddit
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAuthenticationURL(t *testing.T) {
-	authenticator := NewAuthenticator("client_id", "client_secret", "http://localhost:8000", "123456789abcdef", "identity")
+	authenticator := NewAuthenticator("client_id", "client_secret", "http://localhost:8000", "USER-AGENT", "123456789abcdef", "identity")
+	authenticator.RequestPermanentToken = true
 	authenticationURL := authenticator.GetAuthenticationURL()
 
-	assert.Equal(t, authenticationURL, "https://www.reddit.com/api/v1/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A8000&response_type=code&scope=identity&state=123456789abcdef")
+	assert.Equal(
+		t,
+		"https://www.reddit.com/api/v1/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A8000&response_type=code&scope=identity&state=123456789abcdef&duration=permanent",
+		authenticationURL)
 }


### PR DESCRIPTION
Google's oauth2 library doesn't allow the `User-Agent` header to be set when calling `Exchange()`. Lacking a `User-Agent`, Reddit's API frequently returns a HTTP 429 (Too many requests) error. Reddit _really_ wants you to use a custom `User-Agent` header with every request.

In this PR I used the cryptic instructions from Google in [this Github issue](https://github.com/golang/oauth2/issues/179) to add a `User-Agent` header to the `Exchange()` request manually. This is kind of a hack, but Google acknowledges the [need for it](https://github.com/golang/oauth2/issues/223).